### PR TITLE
CMake simplify

### DIFF
--- a/SquirrelDefender/Building-SquirrelDefender.md
+++ b/SquirrelDefender/Building-SquirrelDefender.md
@@ -4,21 +4,32 @@ This folder contains the code for the Squirrel Defender and most of its dependen
 
 ## Follow the instructions in the scripts folder to set up swap and install the needed dependencies first
 
-## Before compiling (specifically when linking ORB_SLAM, and pango directly)
+## Before compiling (specifically if linking ORB_SLAM)
 
-- Follow the instructions here to update the linker path <https://stackoverflow.com/questions/480764/linux-error-while-loading-shared-libraries-cannot-open-shared-object-file-no-s>
-- Copy all .so files from `SquirrelDefender/lib/` to `/usr/local/lib/` on the jetson
-- Copy all folders from `SquirrelDefender/inc/` to `/usr/local/include/` on the jetson
-- Updated the shared library cache with `sudo ldconfig -v`
+- Follow the instructions in [Install-dependencies](https://github.com/crose72/OperationSquirrel/blob/dev/scripts/Install-dependencies.md) to copy the contents of `jetson/usr-orin-nano` or the specific library files for your device to the correct path.
+- Update the shared library cache with `sudo ldconfig -v` (should be part of the steps for the bullet point above)
+- If you need to update the linker path for some reason <https://stackoverflow.com/questions/480764/linux-error-while-loading-shared-libraries-cannot-open-shared-object-file-no-s>
 
-## CMakeLists explanation
+## CMake instructions
 
-- Enable either USE_JETSON or USE_WSL by turning them ON or OFF (only one at a time)
-  - `option(USE_JETSON "Enable Jetson Nano specific features" ON)`
-  - `option(USE_WSL "Enable WSL specific features" OFF)`
-- Default release is `Debug` (enables print statements).  To turn off print statements and other debugging
-  features compile a Release type build
-  - `cmake -DCMAKE_BUILD_TYPE=Release ..`
+First you will want to update CMake to 3.28, the version we are currently using.  The Jetson Nano is arm64 or aarch64 so the appropriate file has been selected.  You only need to do this once.
+
+```
+# Remove old version of cmake and install a newer one
+	sudo apt-get remove cmake  # or your package manager's equivalent command
+
+# Replace <version> with the version number you downloaded
+	wget https://cmake.org/files/v3.28/cmake-3.28.0-linux-aarch64.sh
+	chmod +x cmake-3.28.0-linux-aarch64.sh
+	sudo ./cmake-3.28.0-linux-aarch64.sh --prefix=/usr/local --exclude-subdir
+```
+
+The CMake file allows you to choose the platform you are compiling for.  Currently the supported options are JETSON_B01 and WSL.  Enable one option at a time:
+- `option(JETSON_B01 "Enable Jetson Nano specific features" ON)`
+- `option(WSL "Enable WSL specific features" OFF)`
+
+You must also specify a Debug or Release build.  Debug enables all print statements.  Release disables most print statements to save throughtput for the program:
+- `cmake -DCMAKE_BUILD_TYPE=Release ..`
 
 #### Other preprocessing directives will be added to configure the code to enable or disable other features
 
@@ -49,7 +60,7 @@ This folder contains the code for the Squirrel Defender and most of its dependen
         ExecStart=<path-to-exe>/squirreldefender
         WorkingDirectory=<path-to-build-folder>//SquirrelDefender/build
         StandardOutput=journal
-        SandardError=journal
+        StandardError=journal
         Restart=always
         User=root
 

--- a/SquirrelDefender/CMakeLists.txt
+++ b/SquirrelDefender/CMakeLists.txt
@@ -1,12 +1,26 @@
-# Require CMake 3.1 or greater for IN_LIST support, 2.8 is for detectnet
+# Require CMake 3.1 or greater for IN_LIST support, 2.8 is for detectnet (Currently using CMake 3.28)
 cmake_minimum_required(VERSION 3.1)
 
 # Project definition
 project(SquirrelDefender)
 
-# Options to enable or disable features
-option(USE_JETSON "Enable Jetson Nano specific features" ON)
-option(USE_WSL "Enable WSL specific features" OFF)
+# Choose ONLY ONE platform for the build 
+option(JETSON_B01 "Compiling for Jetson Nano B01" ON)
+option(WSL "Compiling for WSL" OFF)
+
+# Ensure only one build platform is selected
+set(BUILD_PLATFORMS 0)
+if(JETSON_B01)
+    math(EXPR BUILD_PLATFORMS "${BUILD_PLATFORMS} + 1")
+endif()
+
+if(WSL)
+    math(EXPR BUILD_PLATFORMS "${BUILD_PLATFORMS} + 1")
+endif()
+
+if(BUILD_PLATFORMS GREATER 1)
+    message(FATAL_ERROR "Error: More than one build platform option is selected. Please select only one of the following options: JETSON_B01, WSL, or other supported options.")
+endif()
 
 # Set the C++ standard
 set(CMAKE_CXX_STANDARD 11)
@@ -20,217 +34,87 @@ endif()
 # Define valid build types
 set(VALID_BUILD_TYPES Debug Release)
 
-# Set default build type to Release if not specified
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type (Debug or Release)")
-endif()
-
 # Validate CMAKE_BUILD_TYPE
 if(NOT CMAKE_BUILD_TYPE IN_LIST VALID_BUILD_TYPES)
   message(FATAL_ERROR "Invalid build type: ${CMAKE_BUILD_TYPE}. Choose either Debug or Release.")
 endif()
 
-# Print the current build type
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
-# Optional: Set specific compiler flags for each build type
+# Compiler flags for each build type
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -g")
 
-# Define a macro for the build type
+# Optional include code into debug or release build
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_definitions(-DDEBUG_BUILD)
 elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_definitions(-DRELEASE_BUILD)
 endif()
 
-# Conditional configurations for Jetson or WSL
-if (USE_JETSON)
-    option(USE_UART "Use UART functionality for Jetson Nano -> SITL or Jetson Nano -> real drone" ON)
-    option(USE_TCP "Use TCP functionality for WSL -> WSL SITL" OFF)
-    add_definitions(-DUSE_JETSON)
+# Optionally include code compiled for Jetson or WSL
+if (JETSON_B01)
+    add_definitions(-DJETSON_B01)
     add_definitions(-DUSE_UART)
-elseif(USE_WSL)
-    option(USE_UART "Use UART functionality for Jetson Nano -> SITL or Jetson Nano -> real drone" OFF)
-    option(USE_TCP "Use TCP functionality for WSL -> WSL SITL" ON)
-    add_definitions(-DUSE_WSL)
+elseif(WSL)
+    add_definitions(-DWSL)
     add_definitions(-DUSE_TCP)
 endif()
 
-# Custom header includes
+# Directories common to all builds
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/apphdr)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/tests)
-
-# Mavlink includes
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/inc/mavlink/v2.0/common)
 
-# Dynalo includes
-include_directories(/usr/local/include/dynalo)
-include_directories(/usr/local/include/dynalo/detail)
-include_directories(/usr/local/include/dynalo/detail/linux)
-include_directories(/usr/local/include/dynalo/detail/macos)
-include_directories(/usr/local/include/dynalo/detail/windows)
+# Jetson B01 specific configurations
+if (JETSON_B01)
 
-# jetson-inference and utils includes
-include_directories(/usr/local/include/jetson-inference)
-include_directories(/usr/local/include/jetson-utils)
+    include_directories(/usr/local/include/JetsonGPIO
+                        /usr/local/include/jetson-inference
+                        /usr/local/include/jetson-utils
+                        ${OpenCV_INCLUDE_DIRS}
+                        ${Pangolin_INCLUDE_DIRS}
+                        /usr/include/eigen3
+                        /usr/local/include
+                        /usr/local/include/sigslot
+                        /usr/local/include/pangolin
+                        /usr/local/include/ORB_SLAM3
+                        /usr/local/include/ORB_SLAM3/include
+                        /usr/local/include/ORB_SLAM3/include/CameraModels
+                        /usr/local/include/Thirdparty/Sophus)
 
-# NaturalSort includes
-include_directories(/usr/local/include/NaturalSort)
-
-# ORB_SLAM3 includes
-include_directories(/usr/local/include/ORB_SLAM3)
-include_directories(/usr/local/include/ORB_SLAM3/CameraModels)
-
-# Pangolin includes
-include_directories(/usr/local/include/pangolin)
-include_directories(/usr/local/include/pangolin/compat)
-include_directories(/usr/local/include/pangolin/console)
-include_directories(/usr/local/include/pangolin/display)
-include_directories(/usr/local/include/pangolin/factory)
-include_directories(/usr/local/include/pangolin/geometry)
-include_directories(/usr/local/include/pangolin/gl)
-include_directories(/usr/local/include/pangolin/gl/compat)
-include_directories(/usr/local/include/pangolin/handler)
-include_directories(/usr/local/include/pangolin/image)
-include_directories(/usr/local/include/pangolin/log)
-include_directories(/usr/local/include/pangolin/plot)
-include_directories(/usr/local/include/pangolin/plot/loaders)
-include_directories(/usr/local/include/pangolin/scene)
-include_directories(/usr/local/include/pangolin/tools)
-include_directories(/usr/local/include/pangolin/utils)
-include_directories(/usr/local/include/pangolin/utils/posix)
-include_directories(/usr/local/include/pangolin/utils/xml)
-include_directories(/usr/local/include/pangolin/var)
-include_directories(/usr/local/include/pangolin/video)
-include_directories(/usr/local/include/pangolin/video/drivers)
-include_directories(/usr/local/include/pangolin/windowing)
-
-# Sigslot includes
-include_directories(/usr/local/include/sigslot)
-
-# Thirdparty includes for ORB_SLAM3
-include_directories(/usr/local/include/Thirdparty)
-include_directories(/usr/local/include/Thirdparty/DBoW2)
-include_directories(/usr/local/include/Thirdparty/DBoW2/DBoW2)
-include_directories(/usr/local/include/Thirdparty/DBoW2/DUtils)
-include_directories(/usr/local/include/Thirdparty/g2o)
-include_directories(/usr/local/include/Thirdparty/g2o/g2o)
-include_directories(/usr/local/include/Thirdparty/g2o/g2o/core)
-include_directories(/usr/local/include/Thirdparty/g2o/g2o/solvers)
-include_directories(/usr/local/include/Thirdparty/g2o/g2o/stuff)
-include_directories(/usr/local/include/Thirdparty/g2o/g2o/types)
-include_directories(/usr/local/include/Thirdparty/Sophus)
-include_directories(/usr/local/include/Thirdparty/Sophus/sophus)
-
-# Tinyobject includes
-include_directories(/usr/local/include/tinyobj)
-
-# Gstreamer includes
-include_directories(/usr/include/gstreamer-1.0/)
-include_directories(/usr/include/glib-2.0/)
-include_directories(/usr/lib/aarch64-linux-gnu/glib-2.0/include/)
-
-# GPIO includes
-include_directories(/usr/local/include/JetsonGPIO)
-
-# Jetson-specific configurations
-if (USE_JETSON)
-    # Import jetson-inference and jetson-utils packages
+    find_package(OpenCV REQUIRED)
+    find_package(Pangolin REQUIRED)
+    find_package(Eigen3 REQUIRED)
     find_package(jetson-utils REQUIRED)
     find_package(jetson-inference REQUIRED)
-    
-    # Find VPI package (optional)
     find_package(VPI 2.0)
-    
-    # CUDA is required
     find_package(CUDA REQUIRED)
-
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(GST REQUIRED gstreamer-1.0)
-    pkg_check_modules(GLIB REQUIRED glib-2.0)
-    pkg_check_modules(GOBJECT REQUIRED gobject-2.0)
-    pkg_check_modules(GST_APP REQUIRED gstreamer-app-1.0)
-
-    # Find the JetsonGPIO library
     find_library(JETSON_GPIO_LIB JetsonGPIO)
 
-    # Include directories for GStreamer and GLib
-    include_directories(${GST_INCLUDE_DIRS})
-    include_directories(${GLIB_INCLUDE_DIRS})
-    include_directories(${GOBJECT_INCLUDE_DIRS})
-    include_directories(${GST_APP_INCLUDE_DIRS})
     link_directories(/usr/lib/aarch64-linux-gnu/tegra)
-
-    # All .so files contained locally
-    link_directories(${CMAKE_CURRENT_SOURCE_DIR}/lib)
 endif()
 
-# Set the source and header directories
+# squirreldefender and source file paths
 set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/appsrc)
 set(HEADER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/apphdr)
 
 # List all source files with .cpp extension
 file(GLOB SOURCES ${SOURCE_DIR}/*.cpp)
-file(GLOB TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/UnitTests/*.cpp)
-
-# List all header files with .h extension
 file(GLOB HEADERS ${HEADER_DIR}/*.h)
 
-# Add the external directory for CppUTest
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty/CppUTest ThirdParty/CppUTest)
-enable_testing()
-
-# Create a static library for the squirreldefender code
-add_library(squirrel_defender_lib STATIC ${SOURCES} ${HEADERS})
-
-# Locate the static library
-find_library(SQUIRREL_DEFENDER_LIB NAMES squirrel_defender_lib PATHS ${STATIC_LIBRARY_DIR})
-
 # Compile the squirreldefender program
-if (USE_JETSON)
+if (JETSON_B01)
     cuda_add_executable(squirreldefender ${SOURCES} ${HEADERS})
-    target_link_libraries(squirreldefender
-        jetson-inference
-        jetson-utils
-        jsoncpp
-        g2o
-        ORB_SLAM3
-        pango_core
-        pango_windowing
-        pango_display
-        pango_geometry
-        pango_glgeometry
-        pango_image
-        pango_opengl
-        pango_packetstream
-        pango_plot
-        pango_python
-        pango_scene
-        pango_tools
-        pango_vars
-        pango_video
-        DBoW2
-        libCatch2.a
-        libCatch2Main.a
-        tinyobj
-        ${GST_LIBRARIES} 
-        ${GLIB_LIBRARIES} 
-        ${GOBJECT_LIBRARIES} 
-        ${GST_APP_LIBRARIES}
-        ${JETSON_GPIO_LIB})
-elseif(USE_WSL)
-    add_executable(squirreldefender ${SOURCES} ${HEADERS})
-endif()
 
-# Compile the unit_tests program
-if (USE_JETSON)
-    cuda_add_executable(unit_tests ${TEST_SOURCES} ${HEADERS})
-    target_link_libraries(unit_tests jetson-inference jsoncpp)
-    add_test(NAME unit_tests COMMAND unit_tests)
-    target_link_libraries(unit_tests squirrel_defender_lib CppUTest CppUTestExt)
-elseif(USE_WSL)
-    add_executable(unit_tests ${TEST_SOURCES} ${HEADERS})
-    add_test(NAME unit_tests COMMAND unit_tests)
-    target_link_libraries(unit_tests squirrel_defender_lib CppUTest CppUTestExt)
+    target_link_libraries(squirreldefender 
+                        ${OpenCV_LIBS} 
+                        ${Pangolin_LIBRARIES} 
+                        ${JETSON_GPIO_LIB}
+                        ORB_SLAM3
+                        jetson-inference
+                        jetson-utils
+                        jsoncpp)
+elseif(WSL)
+    add_executable(squirreldefender ${SOURCES} ${HEADERS})
 endif()

--- a/SquirrelDefender/apphdr/follow_target.h
+++ b/SquirrelDefender/apphdr/follow_target.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
 /********************************************************************************
  * @file    follow_target.h
@@ -81,4 +81,4 @@ private:
 
 #endif // FOLLOW_TARGET_H
 
-#endif // USE_JETSON
+#endif // JETSON_B01

--- a/SquirrelDefender/apphdr/jetson_IO.h
+++ b/SquirrelDefender/apphdr/jetson_IO.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
 /********************************************************************************
  * @file    jetson_IO.h
@@ -53,4 +53,4 @@ private:
 
 #endif // JETSON_IO_H
 
-#endif // USE_JETSON
+#endif // JETSON_B01

--- a/SquirrelDefender/apphdr/object_detection.h
+++ b/SquirrelDefender/apphdr/object_detection.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
 /********************************************************************************
  * @file    object_detection.h
@@ -74,4 +74,4 @@ private:
 
 #endif // OBJECT_DETECTION_H
 
-#endif // USE_JETSON
+#endif // JETSON_B01

--- a/SquirrelDefender/apphdr/parameters.h
+++ b/SquirrelDefender/apphdr/parameters.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
 /********************************************************************************
  * @file    parameters.h
@@ -32,20 +32,20 @@
 /********************************************************************************
  * Function prototypes and Class Definitions
  ********************************************************************************/
-class Parameters {
-    public:
-        Parameters(const std::string& filename);
-        ~Parameters();
+class Parameters
+{
+public:
+    Parameters(const std::string &filename);
+    ~Parameters();
 
-        float get_float_param(const std::string& group, const std::string& key) const;
-        uint32_t get_uint32_param(const std::string& group, const std::string& key) const;
-        bool get_bool_param(const std::string& group, const std::string& key) const;
+    float get_float_param(const std::string &group, const std::string &key) const;
+    uint32_t get_uint32_param(const std::string &group, const std::string &key) const;
+    bool get_bool_param(const std::string &group, const std::string &key) const;
 
-    private:
-        Json::Value root;
+private:
+    Json::Value root;
 };
-
 
 #endif // PARAMETERS_H
 
-#endif // USE_JETSON
+#endif // JETSON_B01

--- a/SquirrelDefender/apphdr/video_IO.h
+++ b/SquirrelDefender/apphdr/video_IO.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
 /********************************************************************************
  * @file    video_IO.h
@@ -16,7 +16,6 @@
 #include "common_inc.h"
 #include "jetson-utils/videoSource.h"
 #include "jetson-utils/videoOutput.h"
-#include "jetson-utils/gstCamera.h"
 #include "jetson-inference/detectNet.h"
 #include "jetson-inference/objectTracker.h"
 #include <jetson-inference/objectTrackerIOU.h>
@@ -64,10 +63,8 @@ public:
     static void delete_video_display_stream(void);
 
 private:
-    static gboolean static_bus_callback(GstBus *bus, GstMessage *message, gpointer data);
-    gboolean bus_callback(GstBus *bus, GstMessage *message, gpointer data); // Used to access a gstreamer pipeline
 };
 
 #endif // VIDEO_IO_H
 
-#endif // USE_JETSON
+#endif // JETSON_B01

--- a/SquirrelDefender/appsrc/datalog.cpp
+++ b/SquirrelDefender/appsrc/datalog.cpp
@@ -112,7 +112,7 @@ void DataLogger::save_to_csv(const std::string &filename, const std::vector<std:
 bool DataLogger::data_log_init(void)
 {
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
     file_name = generate_unique_filename(dataFileName);
     data.push_back({"Time",
@@ -181,7 +181,7 @@ bool DataLogger::data_log_init(void)
                     "mav_veh_repr_offset_q[2]",
                     "mav_veh_repr_offset_q[3]"});
 
-#elif USE_WSL
+#elif WSL
 
     data.push_back({"Time",
                     "Voltage Battery",
@@ -231,7 +231,7 @@ bool DataLogger::data_log_init(void)
                     "mav_veh_repr_offset_q[2]",
                     "mav_veh_repr_offset_q[3]"});
 
-#endif // USE_JETSON
+#endif // JETSON_B01
 
     save_to_csv(file_name, data);
 
@@ -247,7 +247,7 @@ void DataLogger::data_log_loop(void)
     // Clear data vector and write to next row
     data.clear();
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
     data.push_back({{std::to_string(app_elapsed_time),
                      std::to_string(system_state),
@@ -315,7 +315,7 @@ void DataLogger::data_log_loop(void)
                      std::to_string(mav_veh_repr_offset_q[2]),
                      std::to_string(mav_veh_repr_offset_q[3])}});
 
-#elif USE_WSL
+#elif WSL
 
     data.push_back({{std::to_string(app_elapsed_time),
                      std::to_string(mav_veh_sys_stat_voltage_battery),
@@ -365,7 +365,7 @@ void DataLogger::data_log_loop(void)
                      std::to_string(mav_veh_repr_offset_q[2]),
                      std::to_string(mav_veh_repr_offset_q[3])}});
 
-#endif // USE_JETSON
+#endif // JETSON_B01
 
     save_to_csv(file_name, data);
 }

--- a/SquirrelDefender/appsrc/follow_target.cpp
+++ b/SquirrelDefender/appsrc/follow_target.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
 /********************************************************************************
  * @file    follow_target.cpp
@@ -353,4 +353,4 @@ void Follow::follow_control_loop(void)
     }
 }
 
-#endif // USE_JETSON
+#endif // JETSON_B01

--- a/SquirrelDefender/appsrc/jetson_IO.cpp
+++ b/SquirrelDefender/appsrc/jetson_IO.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
 /********************************************************************************
  * @file    jetson_IO.cpp
@@ -185,7 +185,6 @@ void StatusIndicators::status_program_complete(void)
     GPIO::output(RED_LED_PIN, GPIO::HIGH);
 }
 
-
 /********************************************************************************
  * Function: gpio_init
  * Description: Initialize the pins on the jetson.
@@ -220,4 +219,4 @@ void StatusIndicators::gpio_shutdown(void)
     GPIO::cleanup();
 }
 
-#endif // USE_JETSON
+#endif // JETSON_B01

--- a/SquirrelDefender/appsrc/main.cpp
+++ b/SquirrelDefender/appsrc/main.cpp
@@ -19,14 +19,14 @@
 #include <mutex>
 #include <signal.h>
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
 #include "jetson_IO.h"
 #include "video_IO.h"
 #include "object_detection.h"
 #include <jsoncpp/json/json.h> // sudo apt-get install libjsoncpp-dev THEN target_link_libraries(your_executable_name jsoncpp)
 
-#endif // USE_JETSON
+#endif // JETSON_B01
 
 /********************************************************************************
  * Typedefs
@@ -41,7 +41,7 @@
  ********************************************************************************/
 TimeCalc MainAppTime;
 bool stop_program;
-std::mutex mutex;
+std::mutex mutex_main;
 
 extern bool save_button_press;
 
@@ -106,7 +106,7 @@ int main(void)
         return 1;
     }
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
     while (!stop_program && !save_button_press)
 
@@ -114,15 +114,15 @@ int main(void)
 
     while (!stop_program)
 
-#endif // USE_JETSON
+#endif // JETSON_B01
 
     {
-        std::lock_guard<std::mutex> lock(mutex);
+        std::lock_guard<std::mutex> lock(mutex_main);
         MainAppTime.calc_elapsed_time();
         SystemController::system_control_loop();
         MavMsg::mav_comm_loop();
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
         Video::video_proc_loop();
         Detection::detection_loop();
@@ -130,11 +130,11 @@ int main(void)
         Video::video_output_loop();
         StatusIndicators::io_loop();
 
-#elif USE_WSL
+#elif WSL
 
         VehicleController::vehicle_control_loop();
 
-#endif // USE_JETSON
+#endif // JETSON_B01
 
         app_first_init();
 
@@ -144,14 +144,14 @@ int main(void)
         MainAppTime.calc_loop_start_time();
     }
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
     Video::shutdown();
     Detection::shutdown();
     StatusIndicators::status_program_complete();
     StatusIndicators::gpio_shutdown();
 
-#endif // USE_JETSON
+#endif // JETSON_B01
 
     VehicleController::vehicle_control_shutdown();
     MavMsg::mav_comm_shutdown();

--- a/SquirrelDefender/appsrc/object_detection.cpp
+++ b/SquirrelDefender/appsrc/object_detection.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
 /********************************************************************************
  * @file    target_tracking.cpp
@@ -40,13 +40,13 @@ int numDetections;
  * Function: Detection
  * Description: Class constructor
  ********************************************************************************/
-Detection::Detection(void){};
+Detection::Detection(void) {};
 
 /********************************************************************************
  * Function: ~Detection
  * Description: Class destructor
  ********************************************************************************/
-Detection::~Detection(void){};
+Detection::~Detection(void) {};
 
 /********************************************************************************
  * Function: create_detection_network
@@ -247,4 +247,4 @@ void Detection::shutdown(void)
     LogVerbose("detectnet:  shutdown complete.\n");
 }
 
-#endif // USE_JETSON
+#endif // JETSON_B01

--- a/SquirrelDefender/appsrc/parameters.cpp
+++ b/SquirrelDefender/appsrc/parameters.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
 /********************************************************************************
  * @file    parameters.cpp
@@ -82,4 +82,4 @@ bool Parameters::get_bool_param(const std::string &group, const std::string &key
     return root[group][key].asBool();
 }
 
-#endif // USE_JETSON
+#endif // JETSON_B01

--- a/SquirrelDefender/appsrc/system_controller.cpp
+++ b/SquirrelDefender/appsrc/system_controller.cpp
@@ -17,12 +17,12 @@
 #include "datalog.h"
 #include "vehicle_controller.h"
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 #include "video_IO.h"
 #include "object_detection.h"
 #include <jsoncpp/json/json.h> //sudo apt-get install libjsoncpp-dev THEN target_link_libraries(your_executable_name jsoncpp)
 #include "follow_target.h"
-#endif // USE_JETSON
+#endif // JETSON_B01
 
 /********************************************************************************
  * Typedefs
@@ -67,7 +67,7 @@ int SystemController::system_init(void)
 {
     systems_initialized = false;
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
     StatusIndicators::gpio_init();
     StatusIndicators::status_initializing();
@@ -91,7 +91,7 @@ int SystemController::system_init(void)
         return 1;
     }
 
-#elif USE_WSL
+#elif WSL
 
     if (!MavMsg::mav_comm_init() ||
         /* !DataLogger::data_log_init() || */
@@ -100,7 +100,7 @@ int SystemController::system_init(void)
         return 1;
     }
 
-#endif // USE_JETSON
+#endif // JETSON_B01
 
     systems_initialized = true;
 
@@ -123,15 +123,15 @@ int SystemController::system_state_machine(void)
         bool mav_type_is_quad = (mav_veh_type == MAV_TYPE_QUADROTOR && mav_veh_autopilot_type == MAV_AUTOPILOT_ARDUPILOTMEGA);
         bool prearm_checks = false;
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
         prearm_checks = ((mav_veh_sys_stat_onbrd_cntrl_snsrs_present & MAV_SYS_STATUS_PREARM_CHECK) != 0 && valid_image_rcvd);
 
-#elif USE_WSL
+#elif WSL
 
         prearm_checks = ((mav_veh_sys_stat_onbrd_cntrl_snsrs_present & MAV_SYS_STATUS_PREARM_CHECK) != 0);
 
-#endif // USE_JETSON
+#endif // JETSON_B01
 
         // Switch case determines how we transition from one state to another
         switch (system_state)
@@ -182,7 +182,7 @@ int SystemController::system_state_machine(void)
     return 0;
 }
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
 /********************************************************************************
  * Function: led_system_indicators
@@ -203,7 +203,7 @@ void SystemController::led_system_indicators(void)
     }
 }
 
-#endif // USE_JETSON
+#endif // JETSON_B01
 
 /********************************************************************************
  * Function: system_control_loop
@@ -213,11 +213,11 @@ void SystemController::system_control_loop(void)
 {
     system_state_machine();
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
     led_system_indicators();
 
-#endif // USE_JETSON
+#endif // JETSON_B01
 }
 
 /********************************************************************************
@@ -226,12 +226,12 @@ void SystemController::system_control_loop(void)
  ********************************************************************************/
 void SystemController::system_shutdown(void)
 {
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
     Video::shutdown();
     Detection::shutdown();
 
-#endif // USE_JETSON
+#endif // JETSON_B01
 
     MavMsg::mav_comm_shutdown();
 }

--- a/SquirrelDefender/appsrc/vehicle_controller.cpp
+++ b/SquirrelDefender/appsrc/vehicle_controller.cpp
@@ -103,7 +103,7 @@ void VehicleController::cmd_acceleration_NED(float acceleration_target[3])
     VelocityController::cmd_acceleration_NED(acceleration_target);
 }
 
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
 /********************************************************************************
  * Function: follow_target
@@ -129,7 +129,7 @@ void VehicleController::follow_mode(void)
     }
 }
 
-#endif // USE_JETSON
+#endif // JETSON_B01
 
 /********************************************************************************
  * Function: vehicle_control_init
@@ -163,7 +163,7 @@ void VehicleController::vehicle_control_loop(void)
     }
     else if (system_state == SYSTEM_STATE::IN_FLIGHT_GOOD)
     {
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
         if (takeoff_dbc_cnt > 0)
         {
@@ -180,7 +180,7 @@ void VehicleController::vehicle_control_loop(void)
             follow_mode();
         }
 
-#elif USE_WSL
+#elif WSL
 
         if (takeoff_dbc_cnt > 0)
         {
@@ -197,7 +197,7 @@ void VehicleController::vehicle_control_loop(void)
             test_flight();
         }
 
-#endif // USE_JETSON
+#endif // JETSON_B01
     }
 }
 

--- a/SquirrelDefender/appsrc/video_IO.cpp
+++ b/SquirrelDefender/appsrc/video_IO.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_JETSON
+#ifdef JETSON_B01
 
 /********************************************************************************
  * @file    videoIO.cpp
@@ -416,4 +416,4 @@ void Video::shutdown(void)
     LogVerbose("video:  shutdown complete.\n");
 }
 
-#endif // USE_JETSON
+#endif // JETSON_B01


### PR DESCRIPTION
Simplifying CMake file, added SLAM compile ability, removing unit test builds for now since they're not being used, and renamed preprocessor directives.